### PR TITLE
Add namespace to provider authority to prevent crashes on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
         <engine name="cordova-plugman" version=">=4.3.0"  />
         <engine name="cordova-android" version=">=6.0.0"  />
         <engine name="cordova-windows" version=">=4.2.0"  />
-        <engine name="android-sdk"     version=">=26" />
+        <!-- <engine name="android-sdk"     version=">=26" /> -->
         <engine name="apple-ios"       version=">=10.0.0" />
     </engines>
 
@@ -99,7 +99,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <provider
                 android:name="de.appplant.cordova.plugin.notification.util.AssetProvider"
-                android:authorities="${applicationId}.provider"
+                android:authorities="${applicationId}.localnotifications.provider"
                 android:exported="false"
                 android:grantUriPermissions="true" >
                 <meta-data

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="0.9.0-beta.3">
+        version="0.9.3-bf-1.2">
 
     <name>LocalNotification</name>
 

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -361,7 +361,7 @@ public final class AssetUtil {
      */
     private Uri getUriFromFile(File file) {
         try {
-            String authority = context.getPackageName() + ".provider";
+            String authority = context.getPackageName() + "localnotifications.provider";
             return AssetProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();


### PR DESCRIPTION
…1772)

* Add namespace to provider authority to prevent crashes on Android.
See https://github.com/katzer/cordova-plugin-local-notifications/issues/1664

* Comment out android-sdk requirement since it's not being applied correctly.
See https://github.com/katzer/cordova-plugin-local-notifications/issues/1561

* oreo bug fix, no smallIcon set in notification (#1792)

* Update AssetUtil.java

Removing Resources.getSystem() to get resource ID because in android 8.1 (physical device) it fire an exception with the DEFALUT_ICON (res://icon) if no smallIcon is set in the notification schedule.
Changed also Options.java for small icon fallback

* Update Options.java

Removed resId = context.getApplicationInfo().icon
The application icon is set always and it is not able to select the resId = android.R.drawable.ic_popup_reminder. This is always set (API 1) and not showing ugly as app icon (notification small icon should be a silhouette)